### PR TITLE
Fixed syntax error on connection variable.

### DIFF
--- a/src/firefoxos/NetworkProxy.js
+++ b/src/firefoxos/NetworkProxy.js
@@ -25,7 +25,7 @@
 
 
 var cordova = require('cordova');
-var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+var connection = navigator.mozConnection || navigator.webkitConnection || navigator.connection;
 
 module.exports = {
     getConnectionInfo: function (win, fail, args) {


### PR DESCRIPTION
I got a syntax error on `var connections = ...`

```
 module.exports = {
      var connection = navigator.connection || navigator.mozConnection
      .....
```

I moved it our from module.exports var to fix it.

```
 var connection = navigator.connection || navigator.mozConnection
 module.exports = {
      .....
```
