### PR TITLE
adding isConnectionRequired check for CELL

### DIFF
--- a/src/ios/CDVConnection.m
+++ b/src/ios/CDVConnection.m
@@ -52,8 +52,14 @@
             return @"none";
 
         case ReachableViaWWAN:
-            return @"cellular";
-
+        {
+            BOOL isConnectionRequired = [reachability connectionRequired];
+            if (isConnectionRequired) {
+                return @"none";
+            } else {
+                return @"cellular";
+            }
+        }
         case ReachableViaWiFi:
             return @"wifi";
 


### PR DESCRIPTION
Reachability can return "ReachableViaWWAN" even in cases such as airplane mode is on. In case of ReachableViaWWAN connectionRequired flag should be checked.

see:
http://stackoverflow.com/questions/19949665/reachability-responding-with-wrong-status-code-in-ios-7-iphone-5
http://forums.macrumors.com/showthread.php?t=942439
