### PR TITLE
[CB-6350] Return cellular connection type even if wifi is reachable on 64-bit iOS

### DIFF
--- a/src/ios/CDVReachability.m
+++ b/src/ios/CDVReachability.m
@@ -205,7 +205,7 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
         return NotReachable;
     }
 
-    BOOL retVal = NotReachable;
+    NetworkStatus retVal = NotReachable;
 
     if ((flags & kSCNetworkReachabilityFlagsConnectionRequired) == 0) {
         // if target host is reachable and no connection is required


### PR DESCRIPTION
Pull request related to:
https://issues.apache.org/jira/browse/CB-6350

This path resolve issue by using NetworkStatus type instead of BOOL, because BOOL is now actually bool on 64-Bit iOS and cannot be used in this case.
