### PR TITLE
Port network tests to plugin-test-framework

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,6 +38,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <js-module src="www/Connection.js" name="Connection">
         <clobbers target="Connection" />
     </js-module>
+    
+    <js-module src="test/tests.js" name="tests">
+    </js-module>
 
     <!-- firefoxos -->
     <platform name="firefoxos">

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,0 +1,58 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+exports.defineAutoTests = function() {
+    describe('Network (navigator.connection)', function () {
+        it("network.spec.1 should exist", function() {
+            expect(navigator.network && navigator.network.connection).toBeDefined();
+            expect(navigator.connection).toBeDefined();
+        });
+
+        it("network.spec.2 should be set to a valid value", function() {
+            var validValues = {
+                'unknown': 1,
+                'ethernet': 1,
+                'wifi': 1,
+                '2g': 1,
+                'cellular': 1,
+                '3g': 1,
+                '4g': 1,
+                'none': 1
+            };
+            expect(validValues[navigator.connection.type]).toBe(1);
+        });
+
+        it("network.spec.3 should have the same value in deprecated and non-deprecated apis", function() {
+            expect(navigator.network.connection.type).toBe(navigator.connection.type);
+        });
+
+        it("network.spec.4 should define constants for connection status", function() {
+            expect(Connection.UNKNOWN).toBe("unknown");
+            expect(Connection.ETHERNET).toBe("ethernet");
+            expect(Connection.WIFI).toBe("wifi");
+            expect(Connection.CELL_2G).toBe("2g");
+            expect(Connection.CELL_3G).toBe("3g");
+            expect(Connection.CELL_4G).toBe("4g");
+            expect(Connection.NONE).toBe("none");
+            expect(Connection.CELL).toBe("cellular");
+        });
+    });
+};


### PR DESCRIPTION
Ported test  from mobile-spec (which are written in jasmine 1.3) in
jasmine 2.0.
Added:
New js-module named tests to plugin.xml
Folder with tests working on jasmine 2.0
