### PR TITLE
[CB-6422] Use cordova/exec/proxy instead of platform dupes

### DIFF
--- a/src/firefoxos/NetworkProxy.js
+++ b/src/firefoxos/NetworkProxy.js
@@ -86,4 +86,4 @@ module.exports = {
   }
 };
 
-require("cordova/firefoxos/commandProxy").add("NetworkStatus", module.exports);
+require("cordova/exec/proxy").add("NetworkStatus", module.exports);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6422
[CB-6422] Use cordova/exec/proxy instead of platform dupes
