### PR TITLE
Fix network information type exception on fxos 2

### DIFF
--- a/src/firefoxos/NetworkProxy.js
+++ b/src/firefoxos/NetworkProxy.js
@@ -34,8 +34,16 @@ module.exports = {
 
   getConnectionInfo: function(successCallback, errorCallback) {
     var connection = origConnection || navigator.mozConnection,
-      connectionType = Connection.UNKNOWN,
-      bandwidth = connection.bandwidth,
+        connectionType = Connection.UNKNOWN;
+
+    if (!connection) {
+        setTimeout(function() {
+            successCallback(connectionType);
+        }, 0);
+        return;
+    }
+
+    var bandwidth = connection.bandwidth,
       metered = connection.metered,
       type = connection.type;
 


### PR DESCRIPTION
`navigator.connection` got removed from fxos 2, causing the plugin to crash when loading. Fixed by returning  `UNKNOWN` when `navigator.connection` is not defined.

This is a quick fix to get this into next release ASAP, I'll now investigate if there's any alternative. There was nothing useful on [the mdn page](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API).
