### PR TITLE
Fixing early calls connection state

### DIFF
--- a/src/browser/NetworkProxy.js
+++ b/src/browser/NetworkProxy.js
@@ -41,12 +41,18 @@ module.exports = {
                 window.navigator.connection.type = Connection.NONE;
             }
         };
+            successCallback(window.navigator.connection.type);
+        };
 
         xhr.send();
 
-        setTimeout(function() {
+        xhr.onerror = function() {
             successCallback(window.navigator.connection.type);
-        }, 0);
+        };
+
+        xhr.onabort = function() {
+            successCallback(window.navigator.connection.type);
+        };
     }
 };
 

--- a/src/browser/NetworkProxy.js
+++ b/src/browser/NetworkProxy.js
@@ -53,6 +53,10 @@ module.exports = {
         xhr.onabort = function() {
             successCallback(window.navigator.connection.type);
         };
+        
+        xhr.ontimeout = function() {
+            successCallback(window.navigator.connection.type);
+        };
     }
 };
 


### PR DESCRIPTION
Our application requests directly "startup values" over an ajax connection.
In the current browser implementation, the network-information plugin always returns "offline" (Conection.None), as the ajax request for google.com has not returned yet.
It is only after a short time that the ajax call returns and give the correct network state.

We propose the callback to be called when the call is finished, to avoid returning an incorrect network state (before evaluation).

Regards

Geoffroy