### PR TITLE
Correct installation command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ wifi connection, and whether the device has an internet connection.
 
 ## Installation
 
-    cordova plugin add cordova-plugin-network-information
+    cordova plugin add org.apache.cordova.network-information
 
 ## Supported Platforms
 


### PR DESCRIPTION
Current command within documentation: ```cordova plugin add cordova-plugin-network-information``` produces 404 error.