### PR TITLE
CB-9542 Browser Proxy not defined correctly

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -146,14 +146,14 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <!-- windows8 -->
     <platform name="windows8">
         <js-module src="src/windows/NetworkInfoProxy.js" name="NetworkInfoProxy">
-            <merges target="" />
+            <runs/>
         </js-module>
     </platform>
 
     <!-- windows -->
     <platform name="windows">
         <js-module src="src/windows/NetworkInfoProxy.js" name="NetworkInfoProxy">
-            <merges target="" />
+            <runs/>
         </js-module>
     </platform>
 
@@ -166,9 +166,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
     <!-- browser -->
     <platform name="browser">
-        <js-module src="www/browser/network.js" name="browserNetwork">
-            <clobbers target="navigator.connection" />
-            <clobbers target="navigator.network.connection" />
+        <js-module src="www/browser/network.js" name="NetworkInfoProxy">
+            <runs/>
         </js-module>
     </platform>
 </plugin>


### PR DESCRIPTION
Redefined to actually use the proxy instead of overwriting(clobbers) the initial implementation.
Verified online/offline events fire.
Changed plugin.xml windows/windows8 to use 'runs' instead of incorrect merges.target=""