### PR TITLE
Fix checks that always evaluate to true.

### DIFF
--- a/src/ios/CDVConnection.m
+++ b/src/ios/CDVConnection.m
@@ -118,7 +118,7 @@
     [self.internetReach startNotifier];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateConnectionType:)
                                                  name:kReachabilityChangedNotification object:nil];
-    if (&UIApplicationDidEnterBackgroundNotification && &UIApplicationWillEnterForegroundNotification) {
+    if (UIApplicationDidEnterBackgroundNotification && UIApplicationWillEnterForegroundNotification) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onPause) name:UIApplicationDidEnterBackgroundNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onResume) name:UIApplicationWillEnterForegroundNotification object:nil];
     }


### PR DESCRIPTION
The compiler in Xcode [Version 7.0 (7A220)] warned on these lines that they always evaluate to true. Sure enough, taking the address of an object is always non-null. Fix this to test that these objects are non-null.