### PR TITLE
Adding cell type to iOS7 and greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ eventually be removed.
 
 ### iOS Quirks
 
-- iOS can't detect the type of cellular network connection.
+- <iOS7 can't detect the type of cellular network connection.
     - `navigator.connection.type` is set to `Connection.CELL` for all cellular data.
 
 ### Windows Phone Quirks

--- a/plugin.xml
+++ b/plugin.xml
@@ -103,6 +103,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <header-file src="src/ios/CDVReachability.h" />
 	    <source-file src="src/ios/CDVReachability.m" />
 	    <framework src="SystemConfiguration.framework" weak="true" />
+	    <framework src="CoreTelephony.framework" />
     </platform>
 
     <!-- blackberry10 -->

--- a/src/ios/CDVConnection.m
+++ b/src/ios/CDVConnection.m
@@ -16,6 +16,7 @@
  specific language governing permissions and limitations
  under the License.
  */
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
 
 #import "CDVConnection.h"
 #import "CDVReachability.h"
@@ -57,6 +58,30 @@
             if (isConnectionRequired) {
                 return @"none";
             } else {
+                CTTelephonyNetworkInfo *telephonyInfo = [CTTelephonyNetworkInfo new];
+    if ([telephonyInfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyGPRS]) {
+        return @"2g";
+    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyEdge]) {
+        return @"2g";
+    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyWCDMA]) {
+        return @"3g";
+    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyHSDPA]) {
+        return @"3g";
+    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyHSUPA]) {
+        return @"3g";
+    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMA1x]) {
+        return @"3g";
+    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMAEVDORev0]) {
+        return @"3g";
+    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMAEVDORevA]) {
+        return @"3g";
+    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMAEVDORevB]) {
+        return @"3g";
+    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyeHRPD]) {
+        return @"3g";
+    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyLTE]) {
+        return @"4g";
+    }
                 return @"cellular";
             }
         }
@@ -118,6 +143,8 @@
     [self.internetReach startNotifier];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateConnectionType:)
                                                  name:kReachabilityChangedNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateConnectionType:)
+                                                 name:CTRadioAccessTechnologyDidChangeNotification object:nil];
     if (UIApplicationDidEnterBackgroundNotification && UIApplicationWillEnterForegroundNotification) {
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onPause) name:UIApplicationDidEnterBackgroundNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onResume) name:UIApplicationWillEnterForegroundNotification object:nil];

--- a/src/ios/CDVConnection.m
+++ b/src/ios/CDVConnection.m
@@ -58,30 +58,32 @@
             if (isConnectionRequired) {
                 return @"none";
             } else {
-                CTTelephonyNetworkInfo *telephonyInfo = [CTTelephonyNetworkInfo new];
-    if ([telephonyInfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyGPRS]) {
-        return @"2g";
-    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyEdge]) {
-        return @"2g";
-    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyWCDMA]) {
-        return @"3g";
-    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyHSDPA]) {
-        return @"3g";
-    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyHSUPA]) {
-        return @"3g";
-    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMA1x]) {
-        return @"3g";
-    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMAEVDORev0]) {
-        return @"3g";
-    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMAEVDORevA]) {
-        return @"3g";
-    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMAEVDORevB]) {
-        return @"3g";
-    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyeHRPD]) {
-        return @"3g";
-    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyLTE]) {
-        return @"4g";
-    }
+                if ([[[UIDevice currentDevice] systemVersion] compare:@"7.0" options:NSNumericSearch] != NSOrderedAscending) {
+                    CTTelephonyNetworkInfo *telephonyInfo = [CTTelephonyNetworkInfo new];
+                    if ([telephonyInfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyGPRS]) {
+                        return @"2g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyEdge]) {
+                        return @"2g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyWCDMA]) {
+                        return @"3g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyHSDPA]) {
+                        return @"3g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyHSUPA]) {
+                        return @"3g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMA1x]) {
+                        return @"3g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMAEVDORev0]) {
+                        return @"3g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMAEVDORevA]) {
+                        return @"3g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyCDMAEVDORevB]) {
+                        return @"3g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyeHRPD]) {
+                        return @"3g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyLTE]) {
+                        return @"4g";
+                    }
+                }
                 return @"cellular";
             }
         }


### PR DESCRIPTION
Using CoreTelephony and currentRadioAccessTechnology, this add the ability to iOS developer to see the radio type (2g,3g,4g) so they can use it in both android and iOS applications.

https://issues.apache.org/jira/browse/CB-10267