### PR TITLE
fixed two potential memory leaks when doing Analyze on iOS 9

### DIFF
--- a/src/ios/CDVReachability.m
+++ b/src/ios/CDVReachability.m
@@ -142,6 +142,9 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
             retVal->reachabilityRef = reachability;
             retVal->localWiFiRef = NO;
         }
+        else {
+            CFRelease(reachability);
+        }
     }
     return retVal;
 }
@@ -155,6 +158,9 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
         if (retVal != NULL) {
             retVal->reachabilityRef = reachability;
             retVal->localWiFiRef = NO;
+        }
+        else {
+            CFRelease(reachability);
         }
     }
     return retVal;


### PR DESCRIPTION
When you perform an Analyze using Xcode 7, two places are identified as potential memory leaks. These should never happen, but the additional code will safely remove these warnings and tidy up if ever the situation did arise.