### PR TITLE
CB-11838 ios: Unregister callback function at the right timing.

### DIFF
--- a/src/ios/CDVReachability.m
+++ b/src/ios/CDVReachability.m
@@ -120,6 +120,7 @@ static void CDVReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRe
 - (void)stopNotifier
 {
     if (reachabilityRef != NULL) {
+        SCNetworkReachabilitySetCallback(reachabilityRef, NULL, NULL);
         SCNetworkReachabilityUnscheduleFromRunLoop(reachabilityRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
     }
 }


### PR DESCRIPTION
### Platforms affected

iOS
### What does this PR do?

Make it so the CDVReachability object unregisters a callback function at the right timing.

We at LINE observed about 40K crashes a day that were suspected to be
caused by the reacahability callback function invoked on an
already-deallocated object. We couldn't reproduced the crash locally
but this patch did reduce the number of crash reports to zero.

Fixed:
https://issues.apache.org/jira/browse/CB-11838
### What testing has been done on this change?

No automated test. I couldn't reproduce an issue that this patch fixes. However, it suppressed a 40K daily crash reports at LINE.
### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [N/A] Added automated test coverage as appropriate for this change.
