### PR TITLE
CB-13914: (android) Fix in plugin config to access AndroidManifest

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,6 +39,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <clobbers target="Connection" />
     </js-module>
 
+    <engines>
+      <engine name="cordova-android" version=">=7.0.0" />
+    </engines>
 
     <!-- android -->
     <platform name="android">
@@ -48,9 +51,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </feature>
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/*">
+        <edit-config file="app/src/main/AndroidManifest.xml" target="/*" mode="merge">
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-        </config-file>
+        </edit-config>
 
         <source-file src="src/android/NetworkManager.java" target-dir="src/org/apache/cordova/networkinformation" />
 


### PR DESCRIPTION
- Network information plugin fails with cordova android >7

### Platforms affected
- (android)

### What does this PR do?
- Fix the compatibility problem with the new folder structure used by the cordova-android >7

### What testing has been done on this change?
- Locally installed a plugin to an ionic application
- I built an android-cordova >7 application that uses network to check the current status and show a message

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change. (is it needed for this change?)
