### PR TITLE
CB-12035 (android) Fix bug [cordova-plugin-network-information] connection info is not reliable on Android 6

### DIFF
--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -28,17 +28,13 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
-import android.net.Network;
 import android.net.NetworkInfo;
-import android.net.NetworkRequest;
 import android.os.Build;
-import android.text.TextUtils;
 
 import java.util.Locale;
 
@@ -90,7 +86,6 @@ public class NetworkManager extends CordovaPlugin {
 
     ConnectivityManager sockMan;
     BroadcastReceiver receiver;
-    private ConnectivityManager.NetworkCallback lollipopAndAboveNetworkCallback;
     private JSONObject lastInfo = null;
 
     /**
@@ -105,11 +100,7 @@ public class NetworkManager extends CordovaPlugin {
         this.sockMan = (ConnectivityManager) cordova.getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
         this.connectionCallbackContext = null;
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            this.registerConnectivityActionReceiver();
-        } else {
-            this.registerLollipopAndAboveNetworkCallback();
-        }
+        this.registerConnectivityActionReceiver();
     }
 
     /**
@@ -156,63 +147,40 @@ public class NetworkManager extends CordovaPlugin {
         super.onResume(multitasking);
 
         this.unregisterReceiver();
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            this.registerConnectivityActionReceiver();
-        } else {
-            this.registerLollipopAndAboveNetworkCallback();
-        }
+        this.registerConnectivityActionReceiver();
     }
 
     //--------------------------------------------------------------------------
     // LOCAL METHODS
     //--------------------------------------------------------------------------
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void registerLollipopAndAboveNetworkCallback() {
-        NetworkRequest.Builder builder = new NetworkRequest.Builder();
-
-        lollipopAndAboveNetworkCallback = new ConnectivityManager.NetworkCallback() {
-
-                @Override
-                public void onAvailable(Network network) {
-                    LOG.d(LOG_TAG, "In the on available: ");
-                    updateConnectionInfoIfWebViewNotNull(sockMan.getActiveNetworkInfo());
-
-                    String connectionType = determineCurrentConnectionType();
-
-                    if(TYPE_NONE.equals(connectionType)) {
-                        LOG.d(LOG_TAG, "ConnectionType none but in the onAvailable");
-                        LOG.d(LOG_TAG, "!!! Switching to unknown, onAvailable states there is a connectivity.");
-                        sendUpdate(TYPE_UNKNOWN);
-                    }
-                    LOG.d(LOG_TAG, "End the on available: ");
-                }
-
-                @Override
-                public void onLost(Network network) {
-                    LOG.d(LOG_TAG, "In the on lost: ");
-                    updateConnectionInfoIfWebViewNotNull(sockMan.getActiveNetworkInfo());
-                    LOG.d(LOG_TAG, "End the on lost: ");
-                }
-        };
-        sockMan.registerNetworkCallback(builder.build(), lollipopAndAboveNetworkCallback);
-    }
-
     private void registerConnectivityActionReceiver() {
         // We need to listen to connectivity events to update navigator.connection
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
-
         if (this.receiver == null) {
             this.receiver = new BroadcastReceiver() {
                 @Override
                 public void onReceive(Context context, Intent intent) {
-                    updateConnectionInfoIfWebViewNotNull(sockMan.getActiveNetworkInfo());
+                    // (The null check is for the ARM Emulator, please use Intel Emulator for better results)
+                    if (NetworkManager.this.webView != null) {
+                        updateConnectionInfo(sockMan.getActiveNetworkInfo());
+                    }
 
-                    String connectionType = determineCurrentConnectionType();
+                    String connectionType = null;
+                    if(NetworkManager.this.lastInfo == null) {
+                        connectionType = TYPE_NONE;
+                    } else {
+                        try {
+                            connectionType = NetworkManager.this.lastInfo.get("type").toString();
+                        } catch (JSONException e) {
+                            LOG.d(LOG_TAG, e.getLocalizedMessage());
+                            connectionType = TYPE_NONE;
+                        }
+                    }
 
-                    LOG.d(LOG_TAG, "Intent " + intent.getAction());
-                    if(TYPE_NONE.equals(connectionType)) {
+                    // Lollipop always returns false for the EXTRA_NO_CONNECTIVITY flag => fix for Android M and above.
+                    if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && TYPE_NONE.equals(connectionType)) {
                         boolean noConnectivity = intent.getBooleanExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY, false);
                         LOG.d(LOG_TAG, "Intent no connectivity: " + noConnectivity);
                         if(noConnectivity) {
@@ -229,39 +197,14 @@ public class NetworkManager extends CordovaPlugin {
         webView.getContext().registerReceiver(this.receiver, intentFilter);
     }
 
-    private String determineCurrentConnectionType() {
-        String connectionType;
-        if(NetworkManager.this.lastInfo == null) {
-            connectionType = TYPE_NONE;
-        } else {
-            try {
-                connectionType = NetworkManager.this.lastInfo.get("type").toString();
-            } catch (JSONException e) {
-                LOG.d(LOG_TAG, e.getLocalizedMessage());
-                connectionType = TYPE_NONE;
-            }
-        }
-        return connectionType;
-    }
-
     private void unregisterReceiver() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            if (this.receiver != null) {
-                try {
-                    webView.getContext().unregisterReceiver(this.receiver);
-                } catch (Exception e) {
-                    LOG.e(LOG_TAG, "Error unregistering network receiver: " + e.getMessage(), e);
-                } finally {
-                    receiver = null;
-                }
-            }
-        } else if(this.lollipopAndAboveNetworkCallback != null) {
+        if (this.receiver != null) {
             try {
-                sockMan.unregisterNetworkCallback(this.lollipopAndAboveNetworkCallback);
+                webView.getContext().unregisterReceiver(this.receiver);
             } catch (Exception e) {
                 LOG.e(LOG_TAG, "Error unregistering network receiver: " + e.getMessage(), e);
             } finally {
-                lollipopAndAboveNetworkCallback = null;
+                receiver = null;
             }
         }
     }
@@ -272,11 +215,7 @@ public class NetworkManager extends CordovaPlugin {
      * @param info the current active network info
      * @return
      */
-    private void updateConnectionInfoIfWebViewNotNull(NetworkInfo info) {
-        // (The null check is for the ARM Emulator, please use Intel Emulator for better results)
-        if (NetworkManager.this.webView == null) {
-            return;
-        }
+    private void updateConnectionInfo(NetworkInfo info) {
         // send update to javascript "navigator.network.connection"
         // Jellybean sends its own info
         JSONObject thisInfo = this.getConnectionInfo(info);

--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -115,10 +115,10 @@ public class NetworkManager extends CordovaPlugin {
     /**
      * Executes the request and returns PluginResult.
      *
-     * @param action          The action to execute.
-     * @param args            JSONArry of arguments for the plugin.
-     * @param callbackContext The callback id used when calling back into JavaScript.
-     * @return True if the action was valid, false otherwise.
+     * @param action            The action to execute.
+     * @param args              JSONArry of arguments for the plugin.
+     * @param callbackContext   The callback id used when calling back into JavaScript.
+     * @return                  True if the action was valid, false otherwise.
      */
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
         if (action.equals("getConnectionInfo")) {
@@ -173,15 +173,15 @@ public class NetworkManager extends CordovaPlugin {
 
         lollipopAndAboveNetworkCallback = new ConnectivityManager.NetworkCallback() {
 
-            @Override
-            public void onAvailable(Network network) {
-                updateConnectionInfoIfWebViewNotNull(sockMan.getActiveNetworkInfo());
-            }
+                @Override
+                public void onAvailable(Network network) {
+                    updateConnectionInfoIfWebViewNotNull(sockMan.getActiveNetworkInfo());
+                }
 
-            @Override
-            public void onLost(Network network) {
-                updateConnectionInfoIfWebViewNotNull(sockMan.getActiveNetworkInfo());
-            }
+                @Override
+                public void onLost(Network network) {
+                    updateConnectionInfoIfWebViewNotNull(sockMan.getActiveNetworkInfo());
+                }
         };
         sockMan.registerNetworkCallback(builder.build(), lollipopAndAboveNetworkCallback);
     }
@@ -200,10 +200,10 @@ public class NetworkManager extends CordovaPlugin {
                     String connectionType = determineCurrentConnectionType();
 
                     LOG.d(LOG_TAG, "Intent " + intent.getAction());
-                    if (TYPE_NONE.equals(connectionType)) {
+                    if(TYPE_NONE.equals(connectionType)) {
                         boolean noConnectivity = intent.getBooleanExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY, false);
                         LOG.d(LOG_TAG, "Intent no connectivity: " + noConnectivity);
-                        if (noConnectivity) {
+                        if(noConnectivity) {
                             LOG.d(LOG_TAG, "Really no connectivity");
                         } else {
                             LOG.d(LOG_TAG, "!!! Switching to unknown, Intent states there is a connectivity.");
@@ -219,7 +219,7 @@ public class NetworkManager extends CordovaPlugin {
 
     private String determineCurrentConnectionType() {
         String connectionType;
-        if (NetworkManager.this.lastInfo == null) {
+        if(NetworkManager.this.lastInfo == null) {
             connectionType = TYPE_NONE;
         } else {
             try {
@@ -243,7 +243,7 @@ public class NetworkManager extends CordovaPlugin {
                     receiver = null;
                 }
             }
-        } else if (this.lollipopAndAboveNetworkCallback != null) {
+        } else if(this.lollipopAndAboveNetworkCallback != null) {
             try {
                 sockMan.unregisterNetworkCallback(this.lollipopAndAboveNetworkCallback);
             } catch (Exception e) {
@@ -268,7 +268,8 @@ public class NetworkManager extends CordovaPlugin {
         // send update to javascript "navigator.network.connection"
         // Jellybean sends its own info
         JSONObject thisInfo = this.getConnectionInfo(info);
-        if (!thisInfo.equals(lastInfo)) {
+        if(!thisInfo.equals(lastInfo))
+        {
             String connectionType = "";
             try {
                 connectionType = thisInfo.get("type").toString();
@@ -294,7 +295,8 @@ public class NetworkManager extends CordovaPlugin {
             // If we are not connected to any network set type to none
             if (!info.isConnected()) {
                 type = TYPE_NONE;
-            } else {
+            }
+            else {
                 type = getType(info);
             }
             extraInfo = info.getExtraInfo();
@@ -343,16 +345,19 @@ public class NetworkManager extends CordovaPlugin {
             LOG.d(LOG_TAG, "wifi : " + WIFI);
             if (type.equals(WIFI)) {
                 return TYPE_WIFI;
-            } else if (type.toLowerCase().equals(TYPE_ETHERNET) || type.toLowerCase().startsWith(TYPE_ETHERNET_SHORT)) {
+            }
+            else if (type.toLowerCase().equals(TYPE_ETHERNET) || type.toLowerCase().startsWith(TYPE_ETHERNET_SHORT)) {
                 return TYPE_ETHERNET;
-            } else if (type.equals(MOBILE) || type.equals(CELLULAR)) {
+            }
+            else if (type.equals(MOBILE) || type.equals(CELLULAR)) {
                 type = info.getSubtypeName().toLowerCase(Locale.US);
                 if (type.equals(GSM) ||
                     type.equals(GPRS) ||
                     type.equals(EDGE) ||
                     type.equals(TWO_G)) {
                     return TYPE_2G;
-                } else if (type.startsWith(CDMA) ||
+                }
+                else if (type.startsWith(CDMA) ||
                     type.equals(UMTS) ||
                     type.equals(ONEXRTT) ||
                     type.equals(EHRPD) ||
@@ -361,14 +366,16 @@ public class NetworkManager extends CordovaPlugin {
                     type.equals(HSPA) ||
                     type.equals(THREE_G)) {
                     return TYPE_3G;
-                } else if (type.equals(LTE) ||
+                }
+                else if (type.equals(LTE) ||
                     type.equals(UMB) ||
                     type.equals(HSPA_PLUS) ||
                     type.equals(FOUR_G)) {
                     return TYPE_4G;
                 }
             }
-        } else {
+        }
+        else {
             return TYPE_NONE;
         }
         return TYPE_UNKNOWN;

--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -175,12 +175,24 @@ public class NetworkManager extends CordovaPlugin {
 
                 @Override
                 public void onAvailable(Network network) {
+                    LOG.d(LOG_TAG, "In the on available: ");
                     updateConnectionInfoIfWebViewNotNull(sockMan.getActiveNetworkInfo());
+
+                    String connectionType = determineCurrentConnectionType();
+
+                    if(TYPE_NONE.equals(connectionType)) {
+                        LOG.d(LOG_TAG, "ConnectionType none but in the onAvailable");
+                        LOG.d(LOG_TAG, "!!! Switching to unknown, onAvailable states there is a connectivity.");
+                        sendUpdate(TYPE_UNKNOWN);
+                    }
+                    LOG.d(LOG_TAG, "End the on available: ");
                 }
 
                 @Override
                 public void onLost(Network network) {
+                    LOG.d(LOG_TAG, "In the on lost: ");
                     updateConnectionInfoIfWebViewNotNull(sockMan.getActiveNetworkInfo());
+                    LOG.d(LOG_TAG, "End the on lost: ");
                 }
         };
         sockMan.registerNetworkCallback(builder.build(), lollipopAndAboveNetworkCallback);

--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -184,7 +184,7 @@ public class NetworkManager extends CordovaPlugin {
                         if(noConnectivity) {
                             LOG.d(LOG_TAG, "Really no connectivity");
                         } else {
-                            LOG.d(LOG_TAG, "!!! Switching to unknown");
+                            LOG.d(LOG_TAG, "!!! Switching to unknown, Intent states there is a connectivity.");
                             sendUpdate(TYPE_UNKNOWN);
                         }
                     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-12035 && https://github.com/apache/cordova-plugin-network-information/issues/64: in case of TYPE_NONE (android bug?) return TYPE_UNKNOWN if ConnectivityManager.EXTRA_NO_CONNECTIVITY from the intent return false.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
android (6+)

### What does this PR do?
For android M and above (6+) I check the EXTRA_NO_CONNECTIVITY flag. (https://developer.android.com/reference/android/net/ConnectivityManager.html#EXTRA_NO_CONNECTIVITY)
If the EXTRA_NO_CONNECTION flag still returns false, the connectionType is set to UNKNOWN.
This workaround dit not work for Lollipop androids. So the correction is only done for 6+ Androids.

### What testing has been done on this change?
Thoroughly testing on my Samsung device (Oreo) and a Lollipop LG.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
