### PR TITLE
chore: drop Node.js v4 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,12 +12,19 @@ image:
   - Visual Studio 2017
 
 environment:
-  nodejs_version: "4"
+  PLATFORM: windows-10-store
+  JUST_BUILD: --justBuild
   matrix:
-    - PLATFORM: windows-10-store
-      JUST_BUILD: --justBuild
+    - nodejs_version: "6"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
+
+platform:
+  - x86
+  - x64
+
 install:
-  - npm cache clean -f
+  - ps: Install-Product node $env:nodejs_version
   - node --version
   - npm install -g cordova-paramedic@https://github.com/apache/cordova-paramedic.git
   - npm install -g cordova

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,86 +1,73 @@
 sudo: false
+
 addons:
   jwt:
     secure: iFkpgKg4VvsMDC/5MSUGZAOM+vVMWqLPK6qgwdMFvCym+eySk0LKRUi9BmgFMyy9qDGVlg8Sqkgg8ElbdjJbai5m2N/0e1MW2YqSGAvJx1FkWp8uaVDmkBCXO+VKOCQmujyxi6RbUPvMhUI5kzjMuKu0pi8QYg/bqLbdBR2TRis=
 env:
   global:
-  - SAUCE_USERNAME=snay
-  - TRAVIS_NODE_VERSION="4.2"
+    - SAUCE_USERNAME=snay
+    - TRAVIS_NODE_VERSION=6
+
+language: node_js
+node_js: 6
+
 matrix:
   include:
-  - env: PLATFORM=browser-chrome
-    os: linux
-    language: node_js
-    node_js: '4.2'
-  - env: PLATFORM=browser-firefox
-    os: linux
-    language: node_js
-    node_js: '4.2'
-  - env: PLATFORM=browser-safari
-    os: linux
-    language: node_js
-    node_js: '4.2'
-  - env: PLATFORM=browser-edge
-    os: linux
-    language: node_js
-    node_js: '4.2'
-  - env: PLATFORM=ios-9.3
-    os: osx
-    osx_image: xcode7.3
-    language: node_js
-    node_js: '4.2'
-  - env: PLATFORM=ios-10.0
-    os: osx
-    osx_image: xcode7.3
-    language: node_js
-    node_js: '4.2'
-  - env: PLATFORM=android-4.4
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - build-tools-26.0.2
-  - env: PLATFORM=android-5.1
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - build-tools-26.0.2
-  - env: PLATFORM=android-6.0
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - build-tools-26.0.2
-  - env: PLATFORM=android-7.0
-    os: linux
-    language: android
-    jdk: oraclejdk8
-    android:
-      components:
-      - tools
-      - build-tools-26.0.2
+    - env: PLATFORM=browser-chrome
+    - env: PLATFORM=browser-firefox
+    - env: PLATFORM=browser-safari
+    - env: PLATFORM=browser-edge
+    - env: PLATFORM=ios-9.3
+      os: osx
+      osx_image: xcode7.3
+    - env: PLATFORM=ios-10.0
+      os: osx
+      osx_image: xcode7.3
+    - env: PLATFORM=android-4.4
+      os: linux
+      language: android
+      jdk: oraclejdk8
+      android:
+        components:
+        - tools
+        - build-tools-26.0.2
+    - env: PLATFORM=android-5.1
+      os: linux
+      language: android
+      jdk: oraclejdk8
+      android:
+        components:
+        - tools
+        - build-tools-26.0.2
+    - env: PLATFORM=android-6.0
+      os: linux
+      language: android
+      jdk: oraclejdk8
+      android:
+        components:
+        - tools
+        - build-tools-26.0.2
+    - env: PLATFORM=android-7.0
+      os: linux
+      language: android
+      jdk: oraclejdk8
+      android:
+        components:
+        - tools
+        - build-tools-26.0.2
 before_install:
-- rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm
-  && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm
-  install $TRAVIS_NODE_VERSION
-- node --version
-- if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
-- if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
-- if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27;
-  fi
-- git clone https://github.com/apache/cordova-paramedic /tmp/paramedic && pushd /tmp/paramedic
-  && npm install && popd
-- npm install -g cordova
+  # `language: android` has no Node.js installed, therefore we need to install it manually
+  - if [[ "$PLATFORM" =~ android ]]; then nvm install $TRAVIS_NODE_VERSION; fi
+  - node --version
+  - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
+  - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
+  - if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25,android-26,android-27; fi
+  - npm install -g cordova-paramedic@https://github.com/apache/cordova-paramedic.git
+  - npm install -g cordova
+
 install:
-- npm install
+  - npm install
+
 script:
-- npm test
-- node /tmp/paramedic/main.js --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce
-  --buildName travis-plugin-network-information-$TRAVIS_JOB_NUMBER
+  - npm test
+  - cordova-paramedic --config pr/$PLATFORM --plugin $TRAVIS_BUILD_DIR --shouldUseSauce --buildName travis-$TRAVIS_REPO_SLUG-$TRAVIS_JOB_NUMBER


### PR DESCRIPTION
Part of apache/cordova#72

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a - development

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Drops EOL Node.js 4 from CI config. BREAKING CHANGE! :)

### Description
<!-- Describe your changes in detail -->

see above.

### Testing
<!-- Please describe in detail how you tested your changes. -->

TravisCI and Appveyor test results.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
