### PR TITLE
(android) Fix Startup crash on Android 10 devices

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -48,7 +48,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </feature>
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/*">
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
         </config-file>
 


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
Before change: install cordova-plugin-network-information, run on emulator or device with Android 10.  App crashes on start up.

After change: app runs normally on Android 10.

### Description
change path to appmanifest file.  Without this change app will crash on startup on Android 10.  Can reproduce easily on either emulator or device.

### Testing
Ran on a variety of emulators and test devices.  Before crash on start.  After runs normally.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [X ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
