### PR TITLE
Android - Fixes https://github.com/apache/cordova-plugin-network-information#110

### DIFF
--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -338,25 +338,25 @@ public class NetworkManager extends CordovaPlugin {
             else if (type.equals(MOBILE) || type.equals(CELLULAR)) {
                 type = info.getSubtypeName().toLowerCase(Locale.US);
                 if (type.equals(GSM) ||
-                        type.equals(GPRS) ||
-                        type.equals(EDGE) ||
-                        type.equals(TWO_G)) {
+                    type.equals(GPRS) ||
+                    type.equals(EDGE) ||
+                    type.equals(TWO_G)) {
                     return TYPE_2G;
                 }
                 else if (type.startsWith(CDMA) ||
-                        type.equals(UMTS) ||
-                        type.equals(ONEXRTT) ||
-                        type.equals(EHRPD) ||
-                        type.equals(HSUPA) ||
-                        type.equals(HSDPA) ||
-                        type.equals(HSPA) ||
-                        type.equals(THREE_G)) {
+                    type.equals(UMTS) ||
+                    type.equals(ONEXRTT) ||
+                    type.equals(EHRPD) ||
+                    type.equals(HSUPA) ||
+                    type.equals(HSDPA) ||
+                    type.equals(HSPA) ||
+                    type.equals(THREE_G)) {
                     return TYPE_3G;
                 }
                 else if (type.equals(LTE) ||
-                        type.equals(UMB) ||
-                        type.equals(HSPA_PLUS) ||
-                        type.equals(FOUR_G)) {
+                    type.equals(UMB) ||
+                    type.equals(HSPA_PLUS) ||
+                    type.equals(FOUR_G)) {
                     return TYPE_4G;
                 }
             }

--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -219,7 +219,7 @@ public class NetworkManager extends CordovaPlugin {
         // send update to javascript "navigator.network.connection"
         // Jellybean sends its own info
         JSONObject thisInfo = this.getConnectionInfo(info);
-        if(!thisInfo.equals(lastInfo))
+        if(connectionInfoDiffersFromLastInfo(thisInfo))
         {
             String connectionType = "";
             try {
@@ -230,7 +230,42 @@ public class NetworkManager extends CordovaPlugin {
 
             sendUpdate(connectionType);
             lastInfo = thisInfo;
+        } else {
+            LOG.d(LOG_TAG, "Networkinfo state didn't change, there is no event propagated to the javascript side.");
         }
+    }
+
+    private boolean connectionInfoDiffersFromLastInfo(JSONObject thisInfo) {
+        // JSONObject.equals does not work, so the equals is done explicit for every key in the object
+        if(lastInfo == null) {
+            return thisInfo != null;
+        }
+
+        if(thisInfo == null) {
+            return true;
+        }
+
+        if (valueInJSONObjectDiffersForKey(thisInfo , lastInfo, "type")) {
+            return true;
+        }
+
+        return valueInJSONObjectDiffersForKey(thisInfo , lastInfo, "extraInfo");
+    }
+
+    private boolean valueInJSONObjectDiffersForKey(JSONObject firstObject, JSONObject secondObject, String key) {
+        if(firstObject.has(key)) {
+            if(secondObject.has(key)) {
+                try {
+                    return !firstObject.getString(key).equals(secondObject.getString(key));
+                } catch (JSONException e) {
+                    LOG.d(LOG_TAG, e.getLocalizedMessage());
+                }
+            }
+
+            return true;
+        }
+
+        return secondObject.has(key);
     }
 
     /**
@@ -303,25 +338,25 @@ public class NetworkManager extends CordovaPlugin {
             else if (type.equals(MOBILE) || type.equals(CELLULAR)) {
                 type = info.getSubtypeName().toLowerCase(Locale.US);
                 if (type.equals(GSM) ||
-                    type.equals(GPRS) ||
-                    type.equals(EDGE) ||
-                    type.equals(TWO_G)) {
+                        type.equals(GPRS) ||
+                        type.equals(EDGE) ||
+                        type.equals(TWO_G)) {
                     return TYPE_2G;
                 }
                 else if (type.startsWith(CDMA) ||
-                    type.equals(UMTS) ||
-                    type.equals(ONEXRTT) ||
-                    type.equals(EHRPD) ||
-                    type.equals(HSUPA) ||
-                    type.equals(HSDPA) ||
-                    type.equals(HSPA) ||
-                    type.equals(THREE_G)) {
+                        type.equals(UMTS) ||
+                        type.equals(ONEXRTT) ||
+                        type.equals(EHRPD) ||
+                        type.equals(HSUPA) ||
+                        type.equals(HSDPA) ||
+                        type.equals(HSPA) ||
+                        type.equals(THREE_G)) {
                     return TYPE_3G;
                 }
                 else if (type.equals(LTE) ||
-                    type.equals(UMB) ||
-                    type.equals(HSPA_PLUS) ||
-                    type.equals(FOUR_G)) {
+                        type.equals(UMB) ||
+                        type.equals(HSPA_PLUS) ||
+                        type.equals(FOUR_G)) {
                     return TYPE_4G;
                 }
             }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/apache/cordova-plugin-network-information/issues/110 .

### Description
<!-- Describe your changes in detail -->

The JSONObject of Android does not have an equals implementation. So the equals between previous networkinfo and new networkinfo state always returned false.
I've explicitly tested all properties of the JSONObject for equality.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I did test it on an Android Nexus 5X Emulator.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary

I didn't prefix the commit, but I did prefix the PR.
