### PR TITLE
Android - Fixes https://github.com/apache/cordova-plugin-network-information#110

### DIFF
--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -338,25 +338,25 @@ public class NetworkManager extends CordovaPlugin {
             else if (type.equals(MOBILE) || type.equals(CELLULAR)) {
                 type = info.getSubtypeName().toLowerCase(Locale.US);
                 if (type.equals(GSM) ||
-                        type.equals(GPRS) ||
-                        type.equals(EDGE) ||
-                        type.equals(TWO_G)) {
+                    type.equals(GPRS) ||
+                    type.equals(EDGE) ||
+                    type.equals(TWO_G)) {
                     return TYPE_2G;
                 }
                 else if (type.startsWith(CDMA) ||
-                        type.equals(UMTS) ||
-                        type.equals(ONEXRTT) ||
-                        type.equals(EHRPD) ||
-                        type.equals(HSUPA) ||
-                        type.equals(HSDPA) ||
-                        type.equals(HSPA) ||
-                        type.equals(THREE_G)) {
+                    type.equals(UMTS) ||
+                    type.equals(ONEXRTT) ||
+                    type.equals(EHRPD) ||
+                    type.equals(HSUPA) ||
+                    type.equals(HSDPA) ||
+                    type.equals(HSPA) ||
+                    type.equals(THREE_G)) {
                     return TYPE_3G;
                 }
                 else if (type.equals(LTE) ||
-                        type.equals(UMB) ||
-                        type.equals(HSPA_PLUS) ||
-                        type.equals(FOUR_G)) {
+                    type.equals(UMB) ||
+                    type.equals(HSPA_PLUS) ||
+                    type.equals(FOUR_G)) {
                     return TYPE_4G;
                 }
             }

--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -219,7 +219,7 @@ public class NetworkManager extends CordovaPlugin {
         // send update to javascript "navigator.network.connection"
         // Jellybean sends its own info
         JSONObject thisInfo = this.getConnectionInfo(info);
-        if(!thisInfo.equals(lastInfo))
+        if(connectionInfoDiffersFromLastInfo(thisInfo))
         {
             String connectionType = "";
             try {
@@ -230,7 +230,42 @@ public class NetworkManager extends CordovaPlugin {
 
             sendUpdate(connectionType);
             lastInfo = thisInfo;
+        } else {
+            LOG.d(LOG_TAG, "Networkinfo state didn't change, there is no event propagated to the javascript side.");
         }
+    }
+
+    private boolean connectionInfoDiffersFromLastInfo(JSONObject thisInfo) {
+        // JSONObject.equals does not work, so the equals is done explicit for every key in the object
+        if(lastInfo == null) {
+            return thisInfo != null;
+        }
+
+        if(thisInfo == null) {
+            return true;
+        }
+
+        if (valueInJSONObjectDiffersForKey(thisInfo , lastInfo, "type")) {
+            return true;
+        }
+
+        return valueInJSONObjectDiffersForKey(thisInfo , lastInfo, "extraInfo");
+    }
+
+    private boolean valueInJSONObjectDiffersForKey(JSONObject firstObject, JSONObject secondObject, String key) {
+        if(firstObject.has(key)) {
+            if(secondObject.has(key)) {
+                try {
+                    return !firstObject.getString(key).equals(secondObject.getString(key));
+                } catch (JSONException e) {
+                    LOG.d(LOG_TAG, e.getLocalizedMessage());
+                }
+            }
+
+            return true;
+        }
+
+        return secondObject.has(key);
     }
 
     /**
@@ -303,25 +338,25 @@ public class NetworkManager extends CordovaPlugin {
             else if (type.equals(MOBILE) || type.equals(CELLULAR)) {
                 type = info.getSubtypeName().toLowerCase(Locale.US);
                 if (type.equals(GSM) ||
-                    type.equals(GPRS) ||
-                    type.equals(EDGE) ||
-                    type.equals(TWO_G)) {
+                        type.equals(GPRS) ||
+                        type.equals(EDGE) ||
+                        type.equals(TWO_G)) {
                     return TYPE_2G;
                 }
                 else if (type.startsWith(CDMA) ||
-                    type.equals(UMTS) ||
-                    type.equals(ONEXRTT) ||
-                    type.equals(EHRPD) ||
-                    type.equals(HSUPA) ||
-                    type.equals(HSDPA) ||
-                    type.equals(HSPA) ||
-                    type.equals(THREE_G)) {
+                        type.equals(UMTS) ||
+                        type.equals(ONEXRTT) ||
+                        type.equals(EHRPD) ||
+                        type.equals(HSUPA) ||
+                        type.equals(HSDPA) ||
+                        type.equals(HSPA) ||
+                        type.equals(THREE_G)) {
                     return TYPE_3G;
                 }
                 else if (type.equals(LTE) ||
-                    type.equals(UMB) ||
-                    type.equals(HSPA_PLUS) ||
-                    type.equals(FOUR_G)) {
+                        type.equals(UMB) ||
+                        type.equals(HSPA_PLUS) ||
+                        type.equals(FOUR_G)) {
                     return TYPE_4G;
                 }
             }

--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -265,23 +265,20 @@ public class NetworkManager extends CordovaPlugin {
     private String getType(NetworkInfo info) {
         String type = info.getTypeName().toLowerCase(Locale.US);
 
-        LOG.d(LOG_TAG, "toLower : " + type.toLowerCase());
+        LOG.d(LOG_TAG, "toLower : " + type);
         LOG.d(LOG_TAG, "wifi : " + WIFI);
         if (type.equals(WIFI)) {
             return TYPE_WIFI;
-        }
-        else if (type.toLowerCase().equals(TYPE_ETHERNET) || type.toLowerCase().startsWith(TYPE_ETHERNET_SHORT)) {
+        } else if (type.toLowerCase().equals(TYPE_ETHERNET) || type.toLowerCase().startsWith(TYPE_ETHERNET_SHORT)) {
             return TYPE_ETHERNET;
-        }
-        else if (type.equals(MOBILE) || type.equals(CELLULAR)) {
+        } else if (type.equals(MOBILE) || type.equals(CELLULAR)) {
             type = info.getSubtypeName().toLowerCase(Locale.US);
             if (type.equals(GSM) ||
                     type.equals(GPRS) ||
                     type.equals(EDGE) ||
                     type.equals(TWO_G)) {
                 return TYPE_2G;
-            }
-            else if (type.startsWith(CDMA) ||
+            } else if (type.startsWith(CDMA) ||
                     type.equals(UMTS) ||
                     type.equals(ONEXRTT) ||
                     type.equals(EHRPD) ||
@@ -290,8 +287,7 @@ public class NetworkManager extends CordovaPlugin {
                     type.equals(HSPA) ||
                     type.equals(THREE_G)) {
                 return TYPE_3G;
-            }
-            else if (type.equals(LTE) ||
+            } else if (type.equals(LTE) ||
                     type.equals(UMB) ||
                     type.equals(HSPA_PLUS) ||
                     type.equals(FOUR_G)) {

--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -86,7 +86,7 @@ public class NetworkManager extends CordovaPlugin {
 
     ConnectivityManager sockMan;
     BroadcastReceiver receiver;
-    private JSONObject lastInfo = null;
+    private String lastTypeOfNetwork;
 
     /**
      * Sets the context of the Command. This can then be used to do things like
@@ -115,13 +115,7 @@ public class NetworkManager extends CordovaPlugin {
         if (action.equals("getConnectionInfo")) {
             this.connectionCallbackContext = callbackContext;
             NetworkInfo info = sockMan.getActiveNetworkInfo();
-            String connectionType = "";
-            try {
-                connectionType = this.getConnectionInfo(info).get("type").toString();
-            } catch (JSONException e) {
-                LOG.d(LOG_TAG, e.getLocalizedMessage());
-            }
-
+            String connectionType = this.getTypeOfNetworkFallbackToTypeNoneIfNotConnected(info);
             PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, connectionType);
             pluginResult.setKeepCallback(true);
             callbackContext.sendPluginResult(pluginResult);
@@ -167,16 +161,11 @@ public class NetworkManager extends CordovaPlugin {
                         updateConnectionInfo(sockMan.getActiveNetworkInfo());
                     }
 
-                    String connectionType = null;
-                    if(NetworkManager.this.lastInfo == null) {
+                    String connectionType;
+                    if(NetworkManager.this.lastTypeOfNetwork == null) {
                         connectionType = TYPE_NONE;
                     } else {
-                        try {
-                            connectionType = NetworkManager.this.lastInfo.get("type").toString();
-                        } catch (JSONException e) {
-                            LOG.d(LOG_TAG, e.getLocalizedMessage());
-                            connectionType = TYPE_NONE;
-                        }
+                        connectionType = NetworkManager.this.lastTypeOfNetwork;
                     }
 
                     // Lollipop always returns false for the EXTRA_NO_CONNECTIVITY flag => fix for Android M and above.
@@ -218,65 +207,25 @@ public class NetworkManager extends CordovaPlugin {
     private void updateConnectionInfo(NetworkInfo info) {
         // send update to javascript "navigator.network.connection"
         // Jellybean sends its own info
-        JSONObject thisInfo = this.getConnectionInfo(info);
-        if(connectionInfoDiffersFromLastInfo(thisInfo))
+        String currentNetworkType = this.getTypeOfNetworkFallbackToTypeNoneIfNotConnected(info);
+        if(currentNetworkType.equals(this.lastTypeOfNetwork))
         {
-            String connectionType = "";
-            try {
-                connectionType = thisInfo.get("type").toString();
-            } catch (JSONException e) {
-                LOG.d(LOG_TAG, e.getLocalizedMessage());
-            }
-
-            sendUpdate(connectionType);
-            lastInfo = thisInfo;
-        } else {
             LOG.d(LOG_TAG, "Networkinfo state didn't change, there is no event propagated to the javascript side.");
+        } else {
+            sendUpdate(currentNetworkType);
+            this.lastTypeOfNetwork = currentNetworkType;
         }
-    }
-
-    private boolean connectionInfoDiffersFromLastInfo(JSONObject thisInfo) {
-        // JSONObject.equals does not work, so the equals is done explicit for every key in the object
-        if(lastInfo == null) {
-            return thisInfo != null;
-        }
-
-        if(thisInfo == null) {
-            return true;
-        }
-
-        if (valueInJSONObjectDiffersForKey(thisInfo , lastInfo, "type")) {
-            return true;
-        }
-
-        return valueInJSONObjectDiffersForKey(thisInfo , lastInfo, "extraInfo");
-    }
-
-    private boolean valueInJSONObjectDiffersForKey(JSONObject firstObject, JSONObject secondObject, String key) {
-        if(firstObject.has(key)) {
-            if(secondObject.has(key)) {
-                try {
-                    return !firstObject.getString(key).equals(secondObject.getString(key));
-                } catch (JSONException e) {
-                    LOG.d(LOG_TAG, e.getLocalizedMessage());
-                }
-            }
-
-            return true;
-        }
-
-        return secondObject.has(key);
     }
 
     /**
-     * Get the latest network connection information
+     * Gets the type of network connection of the NetworkInfo input
      *
      * @param info the current active network info
-     * @return a JSONObject that represents the network info
+     * @return type the type of network
      */
-    private JSONObject getConnectionInfo(NetworkInfo info) {
-        String type = TYPE_NONE;
-        String extraInfo = "";
+    private String getTypeOfNetworkFallbackToTypeNoneIfNotConnected(NetworkInfo info) {
+        // the info might still be null in this part of the code
+        String type;
         if (info != null) {
             // If we are not connected to any network set type to none
             if (!info.isConnected()) {
@@ -285,22 +234,12 @@ public class NetworkManager extends CordovaPlugin {
             else {
                 type = getType(info);
             }
-            extraInfo = info.getExtraInfo();
+        } else {
+            type = TYPE_NONE;
         }
 
         LOG.d(LOG_TAG, "Connection Type: " + type);
-        LOG.d(LOG_TAG, "Connection Extra Info: " + extraInfo);
-
-        JSONObject connectionInfo = new JSONObject();
-
-        try {
-            connectionInfo.put("type", type);
-            connectionInfo.put("extraInfo", extraInfo);
-        } catch (JSONException e) {
-            LOG.d(LOG_TAG, e.getLocalizedMessage());
-        }
-
-        return connectionInfo;
+        return type;
     }
 
     /**
@@ -324,26 +263,25 @@ public class NetworkManager extends CordovaPlugin {
      * @return the type of mobile network we are on
      */
     private String getType(NetworkInfo info) {
-        if (info != null) {
-            String type = info.getTypeName().toLowerCase(Locale.US);
+        String type = info.getTypeName().toLowerCase(Locale.US);
 
-            LOG.d(LOG_TAG, "toLower : " + type.toLowerCase());
-            LOG.d(LOG_TAG, "wifi : " + WIFI);
-            if (type.equals(WIFI)) {
-                return TYPE_WIFI;
-            }
-            else if (type.toLowerCase().equals(TYPE_ETHERNET) || type.toLowerCase().startsWith(TYPE_ETHERNET_SHORT)) {
-                return TYPE_ETHERNET;
-            }
-            else if (type.equals(MOBILE) || type.equals(CELLULAR)) {
-                type = info.getSubtypeName().toLowerCase(Locale.US);
-                if (type.equals(GSM) ||
+        LOG.d(LOG_TAG, "toLower : " + type.toLowerCase());
+        LOG.d(LOG_TAG, "wifi : " + WIFI);
+        if (type.equals(WIFI)) {
+            return TYPE_WIFI;
+        }
+        else if (type.toLowerCase().equals(TYPE_ETHERNET) || type.toLowerCase().startsWith(TYPE_ETHERNET_SHORT)) {
+            return TYPE_ETHERNET;
+        }
+        else if (type.equals(MOBILE) || type.equals(CELLULAR)) {
+            type = info.getSubtypeName().toLowerCase(Locale.US);
+            if (type.equals(GSM) ||
                     type.equals(GPRS) ||
                     type.equals(EDGE) ||
                     type.equals(TWO_G)) {
-                    return TYPE_2G;
-                }
-                else if (type.startsWith(CDMA) ||
+                return TYPE_2G;
+            }
+            else if (type.startsWith(CDMA) ||
                     type.equals(UMTS) ||
                     type.equals(ONEXRTT) ||
                     type.equals(EHRPD) ||
@@ -351,18 +289,14 @@ public class NetworkManager extends CordovaPlugin {
                     type.equals(HSDPA) ||
                     type.equals(HSPA) ||
                     type.equals(THREE_G)) {
-                    return TYPE_3G;
-                }
-                else if (type.equals(LTE) ||
+                return TYPE_3G;
+            }
+            else if (type.equals(LTE) ||
                     type.equals(UMB) ||
                     type.equals(HSPA_PLUS) ||
                     type.equals(FOUR_G)) {
-                    return TYPE_4G;
-                }
+                return TYPE_4G;
             }
-        }
-        else {
-            return TYPE_NONE;
         }
         return TYPE_UNKNOWN;
     }

--- a/src/android/NetworkManager.java
+++ b/src/android/NetworkManager.java
@@ -265,7 +265,6 @@ public class NetworkManager extends CordovaPlugin {
         String type = info.getTypeName().toLowerCase(Locale.US);
 
         LOG.d(LOG_TAG, "toLower : " + type);
-        LOG.d(LOG_TAG, "wifi : " + WIFI);
         if (type.equals(WIFI)) {
             return TYPE_WIFI;
         } else if (type.toLowerCase().equals(TYPE_ETHERNET) || type.toLowerCase().startsWith(TYPE_ETHERNET_SHORT)) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #101 
Fixes https://github.com/apache/cordova-plugin-network-information/issues/110
Fixes #93

### Description
<!-- Describe your changes in detail -->

The JSONObject of Android does not have an equals implementation. So the equals between previous networkinfo and new networkinfo state always returned false.
I've explicitly tested all properties of the JSONObject for equality.

After a review I noticed that the "extraInfo' value of the JSONObject was not used and needed at all. So I did simplify the plugin to keep the state in a String member. So now the equality is done on a simple String object.

### Testing
<!-- Please describe in detail how you tested your changes. -->

I did test it on an Android Nexus 5X Emulator and on my Samsung .

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change => Was not necessary
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary. => Was not necessary.

I didn't prefix the commit, but I did prefix the PR.


This replaces https://github.com/apache/cordova-plugin-network-information/pull/111 . The original was started from the master branche. This PR is started from a bugfix-branche.