### PR TITLE
chore: bumps version to 3.0.0-dev in test files

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-network-information-tests",
-  "version": "2.0.3-dev",
+  "version": "3.0.0-dev",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-network-information-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-network-information-tests"
-    version="2.0.3-dev">
+    version="3.0.0-dev">
     <name>Cordova Network Information Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
This fixes the missing bumps of the files in the `tests` folder from #118. Thanks to @PieterVanPoyer for catching these.