### PR TITLE
Change Navigator.connection types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,8 +45,9 @@ interface Connection {
      *     Connection.CELL
      *     Connection.NONE
      */
-	type: ConnectionType;
-    
+    type: ConnectionType;
+    dispatchEvent(): boolean;
+
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,7 +45,8 @@ interface Connection {
      *     Connection.CELL
      *     Connection.NONE
      */
-    type: string;
+	type: ConnectionType;
+    
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }


### PR DESCRIPTION
### Platforms affected
All typescript projects


### Motivation and Context
Fixes "Wrong typing for Connection" (#143)


### Description
Adds `dispatchEvent()` to `Navigator.connection`
Change `Connection.type` from string to `ConnectionType`


### Testing
Compilating after the changes



### Checklist
- [ ] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above 
- [x] I've updated the documentation if necessary
