### PR TITLE
(iOS) Check 5G network in iOS platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ wifi connection, and whether the device has an internet connection.
 - Connection.CELL_2G
 - Connection.CELL_3G
 - Connection.CELL_4G
+- Connection.CELL_5G
 - Connection.CELL
 - Connection.NONE
 
@@ -81,6 +82,7 @@ function checkConnection() {
     states[Connection.CELL_2G]  = 'Cell 2G connection';
     states[Connection.CELL_3G]  = 'Cell 3G connection';
     states[Connection.CELL_4G]  = 'Cell 4G connection';
+    states[Connection.CELL_5G]  = 'Cell 5G connection';
     states[Connection.CELL]     = 'Cell generic connection';
     states[Connection.NONE]     = 'No network connection';
 

--- a/src/ios/CDVConnection.m
+++ b/src/ios/CDVConnection.m
@@ -83,6 +83,14 @@
                     } else if ([telephonyInfo.currentRadioAccessTechnology  isEqualToString:CTRadioAccessTechnologyLTE]) {
                         return @"4g";
                     }
+
+                    if (@available(iOS 14.1, *)) {
+                    if ([telephonyInfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyNRNSA]) {
+                        return @"5g";
+                    } else if ([telephonyInfo.currentRadioAccessTechnology isEqualToString:CTRadioAccessTechnologyNR]) {
+                        return @"5g";
+                    }
+                }
                 }
                 return @"cellular";
             }
@@ -106,6 +114,7 @@
     return [theConnectionType isEqualToString:@"2g"] ||
            [theConnectionType isEqualToString:@"3g"] ||
            [theConnectionType isEqualToString:@"4g"] ||
+           [theConnectionType isEqualToString:@"5g"] ||
            [theConnectionType isEqualToString:@"cellular"];
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,6 +42,7 @@ interface Connection {
      *     Connection.CELL_2G
      *     Connection.CELL_3G
      *     Connection.CELL_4G
+     *     Connection.CELL_5G
      *     Connection.CELL
      *     Connection.NONE
      */
@@ -57,6 +58,7 @@ declare var Connection: {
     CELL_2G: string;
     CELL_3G: string;
     CELL_4G: string;
+    CELL_5G: string;
     CELL: string;
     NONE: string;
 }

--- a/www/Connection.js
+++ b/www/Connection.js
@@ -29,6 +29,7 @@ module.exports = {
     CELL_2G: '2g',
     CELL_3G: '3g',
     CELL_4G: '4g',
+    CELL_5G: '5g',
     CELL: 'cellular',
     NONE: 'none'
 };


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
Currently we cannot check if it is 5G network. This PR will help to check 5G network.
It partially fix 5G detection issue. https://github.com/apache/cordova-plugin-network-information/issues/125

### Description
I have added the code that detects 5G using CTTelephonyNetworkInfo.



### Checklist

- [ ] Commit has been prefixed with `(iOS)`
- [ ] This Pull Request partially resolves an issue, I linked to the issue in the text above ([5G detection](https://github.com/apache/cordova-plugin-network-information/issues/125))
- [ ] I've updated the documentation.
