### PR TITLE
fix(ios): remove redundant #import <netinet6/in6.h> for Xcode 26.4 compatibility

### DIFF
--- a/src/ios/CDVReachability.m
+++ b/src/ios/CDVReachability.m
@@ -46,7 +46,6 @@
 
 #import <sys/socket.h>
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>


### PR DESCRIPTION
## Summary
Fixes #165

Xcode 26.4 enforces stricter module boundaries and rejects the private header `netinet6/in6.h` when imported directly from `CDVReachability.m`, causing iOS builds to fail:

```
CDVReachability.m:49:9: error: Use of private header from outside its module: 'netinet6/in6.h'
```

## Change
Remove the redundant `#import <netinet6/in6.h>` from `src/ios/CDVReachability.m`.

This import is unnecessary because:
- `netinet/in.h` (already imported on the previous line) transitively includes `netinet6/in6.h`
- No IPv6-specific types (`sockaddr_in6`, `in6_addr`, `IN6_*`) from `netinet6/in6.h` are used directly in `CDVReachability.m`

## Testing
Verified with production Cordova builds (cordova-ios 7.1.0, Cordova CLI 13.0.0) on Xcode 26.4 (17E192). Both debug IPA and APK build successfully after the fix.