### PR TITLE
chore(workflow): fix verify target release version for plugins

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -68,14 +68,14 @@ jobs:
       - name: Verify Target Release Version
         run: |
           PACKAGE_VERSION=$(jq -r '.version' package.json)
-          if [ $PACKAGE_VERSION != "$TARGET_RELEASE_VERSION" ]; then
+          if [ "$PACKAGE_VERSION" != "$TARGET_RELEASE_VERSION" ]; then
             echo "Mismatch version detected between tag version ($TARGET_RELEASE_VERSION) and package version ($PACKAGE_VERSION)"
             exit 1
           fi
 
           if [ -f "plugin.xml" ]; then
-            PLUGIN_VERSION=$(yq -p=xml -o=json '.plugin.+@version' plugin.xml)
-            if [ $PLUGIN_VERSION != "$TARGET_RELEASE_VERSION" ]; then
+            PLUGIN_VERSION=$(yq -p=xml -o=json '.plugin.+@version' plugin.xml | jq -r .)
+            if [ "$PLUGIN_VERSION" != "$TARGET_RELEASE_VERSION" ]; then
               echo "Mismatch version detected between tag version ($TARGET_RELEASE_VERSION) and plugin version ($PLUGIN_VERSION)"
               exit 1
             fi


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fix issue in the verify target release version step for plugins

### Description
<!-- Describe your changes in detail -->

`yq` outputs the extracted XML attribute as a JSON string (quoted). Pipe to `jq -r` to normalize it to a raw value for shell comparison.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Locally in a test script.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
